### PR TITLE
Correct 'Avg Forgetting' metric

### DIFF
--- a/experiment/metrics.py
+++ b/experiment/metrics.py
@@ -22,7 +22,7 @@ def compute_performance(end_task_acc_arr):
     # compute forgetting
     best_acc = np.max(end_task_acc_arr, axis=1)
     final_forgets = best_acc - end_acc
-    avg_fgt = np.mean(final_forgets, axis=1)
+    avg_fgt = np.mean(final_forgets[:, :-1], axis=1)  # Discard the final task when calculating FGT
     avg_end_fgt = (np.mean(avg_fgt), t_coef * sem(avg_fgt))
 
     # compute ACC


### PR DESCRIPTION
Greetings! I just made a correction to the calculation of the Average Forgetting. The final task is excluded from the calculation as per Eq (4). This error doesn't have much impact on the results in the paper as there are many tasks in the task streams. But we still need to correct it as it would affect when the number of tasks is small. 